### PR TITLE
refactor(MH-65): rename fork to smartmirror-module-OnSpotify

### DIFF
--- a/css/included.css
+++ b/css/included.css
@@ -190,7 +190,7 @@
 /* >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> END < */
 
 /* MODULE HL */
-.MMM-OnSpotify.module {
+.smartmirror-module-OnSpotify.module {
     display: flex;
     justify-content: center;
     font-size: var(--ONSP-INTERNAL-PLAYER-FONT-BASE);

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# install.sh - install Node dependencies for this module on the device.
+# Run automatically by smartmirror-automation/system/module-installer.sh after clone
+# (the universal installer does not run npm install itself).
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+if command -v npm >/dev/null 2>&1; then
+  echo "[install] smartmirror-module-OnSpotify: installing Node dependencies..."
+  npm install --production --no-audit --no-fund
+else
+  echo "[install] npm not found; skipping dependency install" >&2
+fi

--- a/smartmirror-module-OnSpotify.js
+++ b/smartmirror-module-OnSpotify.js
@@ -9,7 +9,7 @@
 
 /* FUTURE: Add a "guessTrackTime" option that still changes the timer even when the update interval window is higher */
 
-Module.register("MMM-OnSpotify", {
+Module.register("smartmirror-module-OnSpotify", {
   defaults: {
     name: "MMM-OnSpotify",
     /* configDeepMerge: true, deepMerge: true, <-- Does not work */


### PR DESCRIPTION
Rename the third-party MMM-OnSpotify fork to the smartmirror-module-* convention so config-monitor detects it for install. Update Module.register name and the .module CSS selector; add install.sh to npm install runtime deps (node-fetch, dompurify) on the device.